### PR TITLE
Switch to env vars from java props to pass in API key

### DIFF
--- a/src/cohere/client.clj
+++ b/src/cohere/client.clj
@@ -7,7 +7,7 @@
   (let [resp (->> options
                 (merge {:as :auto
                         :content-type :json
-                        :headers {"Authorization" (str "Bearer " (System/getProperty "cohere.api.key"))
+                        :headers {"Authorization" (str "Bearer " (System/getenv "COHERE_API_KEY"))
                                   "Request-Source" "clojure-sdk"}})
                 (client/post (str api-endpoint endpoint)))]
     (when-let [warning (get-in resp [:headers "x-api-warning"])]
@@ -16,7 +16,7 @@
 
 (defn check-api-key []
   (let [options {:as :auto
-                 :headers {"Authorization" (str "Bearer " (System/getProperty "cohere.api.key"))
+                 :headers {"Authorization" (str "Bearer " (System/getenv "COHERE_API_KEY"))
                            "Request-Source" "clojure-sdk"}}]
     (:body (client/post "https://api.cohere.ai/check-api-key" options))))
 


### PR DESCRIPTION
A suggestion to switch from `System/getProperties` to `System/getenv`

As discussed [here](https://stackoverflow.com/questions/13112038/difference-between-system-getenv-system-getproperty
) `getenv` will get OS env properties, while `getProperties` deals with whatever is passed into Java env

Note that `x.y` naming needs changing to `X_Y` since the first one is an invalid OS env name.

If keeping `getProps` what is your suggestion on the best pattern to pass the key in? For example when starting cider, deploying etc.